### PR TITLE
docs: fix incorrect "MDM platform" product description

### DIFF
--- a/src/app/page.mdx
+++ b/src/app/page.mdx
@@ -6,19 +6,19 @@ export { Layout as default } from '@/components/Layout'
 
 ## SecPal is being built {{ date: '2026-04-10T00:00Z' }}
 
-SecPal is a security-focused mobile device management platform built for modern organisations. We are building openly — every feature, improvement, and Android release will be documented here as it ships.
+SecPal is the operations software for German private security services. Everything the day-to-day operation needs — in one system that just works. We are building openly — every feature, improvement, and Android release will be documented here as it ships.
 
 This changelog covers all parts of the SecPal stack:
 
 - **Android app** (`app.secpal`) — distributed via direct APK, Obtainium, and GitHub Releases, with enterprise Device Owner provisioning
-- **API** (`api.secpal.dev`) — the backend powering authentication, passkeys, and device policy
+- **API** (`api.secpal.dev`) — the backend powering authentication, guard book, and operational data
 - **Web app** (`app.secpal.dev`) — the browser-based PWA
 
 ### <SparkleIcon /> What we are working on
 
 - Passkey-first authentication (WebAuthn / FIDO2) — no passwords required
+- Guard book, shift planning, and operational workflows
 - Android enterprise enrolment with provisioning QR codes
-- Organisation and device management dashboard
 - Multi-factor recovery and audit logging
 
 Follow the [RSS feed](/feed.xml) or check back here to stay up to date.


### PR DESCRIPTION
## Summary

Corrects a factually wrong product description in `src/app/page.mdx`.

SecPal was described as a "security-focused mobile device management platform built for modern organisations" — that is the wrong product category and the wrong audience.

**Before:** "security-focused mobile device management platform built for modern organisations"
**After:** "the operations software for German private security services. Everything the day-to-day operation needs — in one system that just works."

Also updates the "What we are working on" list to reflect the actual operational focus (guard book, shift planning, operational workflows) instead of "Organisation and device management dashboard".

## Checklist

- [x] One topic, one PR
- [x] No behavior change — documentation only
- [x] `CHANGELOG.md` not required for docs-only fix
- [x] Commit is GPG-signed

Closes #21
Part of SecPal/.github#340