### PR TITLE
docs: fix remaining MDM product description in layout, Intro, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # SecPal Changelog
 
-Public changelog for SecPal — security-focused mobile device management.
+Public changelog for SecPal — operations software for German private security services.
 
 Live at [changelog.secpal.app](https://changelog.secpal.app).
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: 'SecPal Changelog',
   description:
-    'Stay up to date with every new feature, improvement, and Android release from SecPal — security-focused mobile device management.',
+    'Stay up to date with every new feature, improvement, and Android release from SecPal — operations software for German private security services.',
   alternates: {
     types: {
       'application/rss+xml': '/feed.xml',

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -47,8 +47,7 @@ export function Intro() {
       </h1>
       <p className="mt-4 text-sm/6 text-gray-300">
         Follow every feature, improvement, and Android release as we build
-        SecPal — security-focused mobile device management for modern
-        organisations.
+        SecPal — operations software for German private security services.
       </p>
       <div className="mt-8 flex flex-wrap justify-center gap-x-1 gap-y-3 sm:gap-x-2 lg:justify-start">
         <IconLink


### PR DESCRIPTION
Closes #23.

## Changes

Three locations missed by PR #22 that still contained the incorrect product
description "security-focused mobile device management for modern organisations":

- `src/app/layout.tsx` — Next.js `<meta name="description">` (served to search
  engines and link previews)
- `src/components/Intro.tsx` — visible sidebar intro text on the live
  changelog site
- `README.md` — repo README

All three replaced with the canonical one-liner agreed in SecPal/.github#340.

## Validation

- `npm run build` passes with zero errors
