### PR TITLE
docs: sharpen hero section copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors
+
 ### Added
 
 - initial site setup based on Tailwind Plus Commit template (commit-ts) with SecPal branding

--- a/src/app/page.mdx
+++ b/src/app/page.mdx
@@ -28,4 +28,4 @@ This changelog covers the full SecPal stack:
 - Android enterprise enrolment with provisioning QR codes
 - Multi-factor recovery and audit logging
 
-Follow the [RSS feed](/feed.xml) or check back here to stay up to date.
+Follow the [RSS feed](/feed.xml) or check back here.

--- a/src/app/page.mdx
+++ b/src/app/page.mdx
@@ -9,19 +9,21 @@ export { Layout as default } from '@/components/Layout'
 
 ---
 
-## SecPal is being built {{ date: '2026-04-10T00:00Z' }}
+## Building SecPal in public {{ date: '2026-04-10T00:00Z' }}
 
-SecPal is the operations software for German private security services. Everything the day-to-day operation needs — in one system that just works. We are building openly — every feature, improvement, and Android release will be documented here as it ships.
+SecPal is the operations software for German private security services. Everything the day-to-day operation needs — in one system that just works.
 
-This changelog covers all parts of the SecPal stack:
+We build in the open. Every feature, improvement, and Android release is documented here as it ships.
 
-- **Android app** (`app.secpal`) — distributed via direct APK, Obtainium, and GitHub Releases, with enterprise Device Owner provisioning
-- **API** (`api.secpal.dev`) — the backend powering authentication, guard book, and operational data
-- **Web app** (`app.secpal.dev`) — the browser-based PWA
+This changelog covers the full SecPal stack:
 
-### <SparkleIcon /> What we are working on
+- **Android app** (`app.secpal`)
+- **API** (`api.secpal.dev`)
+- **Web app** (`app.secpal.dev`)
 
-- Passkey-first authentication (WebAuthn / FIDO2) — no passwords required
+### <SparkleIcon /> What's in progress
+
+- Passkey-first authentication (WebAuthn / FIDO2)
 - Guard book, shift planning, and operational workflows
 - Android enterprise enrolment with provisioning QR codes
 - Multi-factor recovery and audit logging


### PR DESCRIPTION
Sharpens the hero/pinned entry in `src/app/page.mdx` for tone, clarity, and conciseness.

## Changes

- **Headline**: "SecPal is being built" → "Building SecPal in public"
- **Intro**: split into two shorter paragraphs; "We are building openly" → "We build in the open."
- **Stack list**: "all parts of the SecPal stack" → "the full SecPal stack"; list items stripped of trailing descriptors (kept bare app identifiers)
- **Section title**: "What we are working on" → "What's in progress"
- **Passkey bullet**: removed appended "— no passwords required"

## Validation

`npm run build` passes cleanly (static export, feed, and CSP generated).

Closes no issue — editorial copy improvement.
