### PR TITLE
feat: add Label, Labels, and WhyItMatters MDX components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Label` and `Labels` components (`src/components/Label.tsx`): lightweight per-entry taxonomy badges with kinds `added | improved | fixed | changed | android | api | web | auth | security | breaking`; neutrals share one style, `security` gets an amber tint, `breaking` a red tint — registered globally in `mdx.tsx` so MDX files need no explicit import
+- `WhyItMatters` component (`src/components/WhyItMatters.tsx`): optional callout line for significant entries; renders as a subtle left-border paragraph with "Why it matters:" prefix — registered globally in `mdx.tsx`
+- demonstrative usage of both components in `src/app/page.mdx`: scope labels on the hero entry, `WhyItMatters` closing the in-progress section
+
 - initial site setup based on Tailwind Plus Commit template (commit-ts) with SecPal branding
 - REUSE/SPDX license compliance for all source files
 - full SecPal governance: branch protections, Copilot instructions, CI/CD workflows, dependabot, CODEOWNERS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors
-
 ### Added
 
 - `Label` and `Labels` components (`src/components/Label.tsx`): lightweight per-entry taxonomy badges with kinds `added | improved | fixed | changed | android | api | web | auth | security | breaking`; neutrals share one style, `security` gets an amber tint, `breaking` a red tint — registered globally in `mdx.tsx` so MDX files need no explicit import
@@ -31,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/generate-csp.mjs`: build-time CSP generator that derives the required `script-src` hashes from exported HTML and produces a deployable nginx snippet
 
 ### Changed
+
+- sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors
 
 - narrowed the Tailwind Plus REUSE attribution so only genuinely Commit-template-derived changelog source files carry `LicenseRef-TailwindPlus`, while original SecPal source files now declare plain AGPL directly in their own SPDX headers
 - replaced the generic changelog brand glyphs with the canonical SecPal logo in the header, reused the canonical `SecPal – A guard's best friend` tagline in the footer, kept the dark brand asset for the always-dark intro sidebar in light mode, switched the `secpal.app` link treatment to the canonical monochrome SecPal logo derived from the frontend brand assets, and added light/dark theme-aware browser icons

--- a/src/app/page.mdx
+++ b/src/app/page.mdx
@@ -11,6 +11,13 @@ export { Layout as default } from '@/components/Layout'
 
 ## Building SecPal in public {{ date: '2026-04-10T00:00Z' }}
 
+<Labels>
+  <Label kind="android">Android</Label>
+  <Label kind="api">API</Label>
+  <Label kind="web">Web</Label>
+  <Label kind="auth">Auth</Label>
+</Labels>
+
 SecPal is the operations software for German private security services. Everything the day-to-day operation needs — in one system that just works.
 
 We build in the open. Every feature, improvement, and Android release is documented here as it ships.
@@ -27,5 +34,9 @@ This changelog covers the full SecPal stack:
 - Guard book, shift planning, and operational workflows
 - Android enterprise enrolment with provisioning QR codes
 - Multi-factor recovery and audit logging
+
+<WhyItMatters>
+  One place that tracks every release across Android, API, and frontend — so operators always know what shipped and why it matters.
+</WhyItMatters>
 
 Follow the [RSS feed](/feed.xml) or check back here.

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import clsx from 'clsx'
+
+export type LabelKind =
+  | 'added'
+  | 'improved'
+  | 'fixed'
+  | 'changed'
+  | 'android'
+  | 'api'
+  | 'web'
+  | 'auth'
+  | 'security'
+  | 'breaking'
+
+interface LabelProps {
+  kind?: LabelKind
+  children: React.ReactNode
+}
+
+const KIND_CLASSES: Record<LabelKind, string> = {
+  added:    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  improved: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  fixed:    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  changed:  'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  android:  'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  api:      'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  web:      'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  auth:     'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  security: 'text-amber-700/80 border-amber-400/40 dark:text-amber-400/70 dark:border-amber-600/40',
+  breaking: 'text-red-700/80   border-red-300/40   dark:text-red-400/70   dark:border-red-700/40',
+}
+
+/**
+ * A small, unobtrusive taxonomy label for changelog entries.
+ *
+ * Usage in MDX (no import needed — globally registered):
+ *   <Labels>
+ *     <Label kind="added">Added</Label>
+ *     <Label kind="android">Android</Label>
+ *   </Labels>
+ *
+ * Supported kinds: added | improved | fixed | changed | android | api | web |
+ *                  auth | security | breaking
+ */
+export function Label({ kind = 'added', children }: LabelProps) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded border px-1.5 py-px text-2xs font-semibold uppercase tracking-wider',
+        KIND_CLASSES[kind],
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+/**
+ * Wrapper that lays out a row of <Label> badges.
+ */
+export function Labels({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-wrap gap-1.5">{children}</div>
+}

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -21,16 +21,23 @@ interface LabelProps {
 }
 
 const KIND_CLASSES: Record<LabelKind, string> = {
-  added:    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  improved: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  fixed:    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  changed:  'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  android:  'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  api:      'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  web:      'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  auth:     'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  security: 'text-amber-700/80 border-amber-400/40 dark:text-amber-400/70 dark:border-amber-600/40',
-  breaking: 'text-red-700/80   border-red-300/40   dark:text-red-400/70   dark:border-red-700/40',
+  added:
+    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  improved:
+    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  fixed:
+    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  changed:
+    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  android:
+    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  api: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  web: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  auth: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  security:
+    'text-amber-700/80 border-amber-400/40 dark:text-amber-400/70 dark:border-amber-600/40',
+  breaking:
+    'text-red-700/80   border-red-300/40   dark:text-red-400/70   dark:border-red-700/40',
 }
 
 /**
@@ -49,7 +56,7 @@ export function Label({ kind = 'added', children }: LabelProps) {
   return (
     <span
       className={clsx(
-        'inline-flex items-center rounded border px-1.5 py-px text-2xs font-semibold uppercase tracking-wider',
+        'inline-flex items-center rounded border px-1.5 py-px text-2xs font-semibold tracking-wider uppercase',
         KIND_CLASSES[kind],
       )}
     >

--- a/src/components/WhyItMatters.tsx
+++ b/src/components/WhyItMatters.tsx
@@ -13,7 +13,7 @@
 export function WhyItMatters({ children }: { children: React.ReactNode }) {
   return (
     <p className="border-l-2 border-sky-600/30 pl-4 text-sm/6 text-gray-500 italic dark:border-sky-500/25 dark:text-gray-400">
-      <span className="not-italic font-semibold text-gray-400 dark:text-gray-500">
+      <span className="font-semibold text-gray-400 not-italic dark:text-gray-500">
         Why it matters:{' '}
       </span>
       {children}

--- a/src/components/WhyItMatters.tsx
+++ b/src/components/WhyItMatters.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 SecPal
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/**
+ * An optional callout line for changelog entries that deserve brief context.
+ * Use sparingly — only for genuinely significant changes.
+ *
+ * Usage in MDX (no import needed — globally registered):
+ *   <WhyItMatters>
+ *     Operators can now enrol devices without manual IT involvement.
+ *   </WhyItMatters>
+ */
+export function WhyItMatters({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="border-l-2 border-sky-600/30 pl-4 text-sm/6 text-gray-500 italic dark:border-sky-500/25 dark:text-gray-400">
+      <span className="not-italic font-semibold text-gray-400 dark:text-gray-500">
+        Why it matters:{' '}
+      </span>
+      {children}
+    </p>
+  )
+}

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -11,6 +11,10 @@ import clsx from 'clsx'
 
 import { FormattedDate } from '@/components/FormattedDate'
 
+// Globally register taxonomy helpers so MDX files need no explicit imports.
+export { Label, Labels } from '@/components/Label'
+export { WhyItMatters } from '@/components/WhyItMatters'
+
 export const a = Link
 
 type ImagePropsWithOptionalAlt = Omit<ImageProps, 'alt'> & { alt?: string }


### PR DESCRIPTION
Adds a lightweight per-entry taxonomy system to the changelog.

## What was added

### `Label` + `Labels` components

- `src/components/Label.tsx`
- Small pill badge with ten supported `kind` values: `added`, `improved`, `fixed`, `changed`, `android`, `api`, `web`, `auth`, `security`, `breaking`
- Visual tiers: neutral muted gray for all standard kinds; subtle amber tint for `security`; subtle red tint for `breaking` — unobtrusive, no sticker chaos
- `Labels` wrapper renders a flex row of badges
- Globally registered via `mdx.tsx` → `useMDXComponents` — no per-file import needed

### `WhyItMatters` component

- `src/components/WhyItMatters.tsx`
- Optional left-border callout paragraph for entries that deserve brief context
- Renders as a subtle sky-border `<p>` with a bold "Why it matters:" prefix
- Globally registered — same as above

### Usage in `page.mdx`

Demonstrates both components on the current hero entry:
- Scope labels (`Android`, `API`, `Web`, `Auth`) right after the `##` heading
- `<WhyItMatters>` closing the in-progress section

## Validation

`npm run build` passes cleanly (TypeScript, static export, feed, CSP).

Related: closes no issue — pure additive feature.
