### PR TITLE
fix: address Copilot review findings from PRs #28 and #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Label` and `Labels` components (`src/components/Label.tsx`): lightweight per-entry taxonomy badges with kinds `added | improved | fixed | changed | android | api | web | auth | security | breaking`; neutrals share one style, `security` gets an amber tint, `breaking` a red tint — registered globally in `mdx.tsx` so MDX files need no explicit import
-- `WhyItMatters` component (`src/components/WhyItMatters.tsx`): optional callout line for significant entries; renders as a subtle left-border paragraph with "Why it matters:" prefix — registered globally in `mdx.tsx`
+- `WhyItMatters` component (`src/components/WhyItMatters.tsx`): optional callout line for significant entries; renders as a subtle left-border callout block with "Why it matters:" prefix — registered globally in `mdx.tsx`
 - demonstrative usage of both components in `src/app/page.mdx`: scope labels on the hero entry, `WhyItMatters` closing the in-progress section
 - initial site setup based on Tailwind Plus Commit template (commit-ts) with SecPal branding
 - REUSE/SPDX license compliance for all source files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - local repository guardrails: `scripts/check-conflict-markers.sh`, `scripts/check-domains.sh`, and `scripts/preflight.sh`
 - `scripts/generate-csp.mjs`: build-time CSP generator that derives the required `script-src` hashes from exported HTML and produces a deployable nginx snippet
 
-### Fixed
-
-- `WhyItMatters` (`src/components/WhyItMatters.tsx`): replaced `<p>` wrapper with `<div>` to accept block-level children without producing invalid HTML
-- `Label` (`src/components/Label.tsx`): extracted `NEUTRAL_KIND_CLASS` constant to eliminate eight identical class string repetitions
-- `CHANGELOG.md`: removed blank-line artifacts within `### Added` and `### Changed` sections left by the duplicate-section merge in #28
-
 ### Changed
 
 - sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors
@@ -44,3 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - linting now uses ESLint 9 flat config with a dedicated TypeScript check in CI and local preflight
 - feed and metadata generation now default safely to `https://changelog.secpal.app` when `NEXT_PUBLIC_SITE_URL` is unset
 - local preflight now fails when the tracked nginx CSP snippet no longer matches the current exported HTML
+
+### Fixed
+
+- `WhyItMatters` (`src/components/WhyItMatters.tsx`): replaced `<p>` wrapper with `<div>` to accept block-level children without producing invalid HTML
+- `Label` (`src/components/Label.tsx`): extracted `NEUTRAL_KIND_CLASS` constant to eliminate eight identical class string repetitions
+- `CHANGELOG.md`: removed blank-line artifacts within `### Added` and `### Changed` sections left by the duplicate-section merge in #28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Label` and `Labels` components (`src/components/Label.tsx`): lightweight per-entry taxonomy badges with kinds `added | improved | fixed | changed | android | api | web | auth | security | breaking`; neutrals share one style, `security` gets an amber tint, `breaking` a red tint — registered globally in `mdx.tsx` so MDX files need no explicit import
 - `WhyItMatters` component (`src/components/WhyItMatters.tsx`): optional callout line for significant entries; renders as a subtle left-border paragraph with "Why it matters:" prefix — registered globally in `mdx.tsx`
 - demonstrative usage of both components in `src/app/page.mdx`: scope labels on the hero entry, `WhyItMatters` closing the in-progress section
-
 - initial site setup based on Tailwind Plus Commit template (commit-ts) with SecPal branding
 - REUSE/SPDX license compliance for all source files
 - full SecPal governance: branch protections, Copilot instructions, CI/CD workflows, dependabot, CODEOWNERS
@@ -26,10 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - local repository guardrails: `scripts/check-conflict-markers.sh`, `scripts/check-domains.sh`, and `scripts/preflight.sh`
 - `scripts/generate-csp.mjs`: build-time CSP generator that derives the required `script-src` hashes from exported HTML and produces a deployable nginx snippet
 
+### Fixed
+
+- `WhyItMatters` (`src/components/WhyItMatters.tsx`): replaced `<p>` wrapper with `<div>` to accept block-level children without producing invalid HTML
+- `Label` (`src/components/Label.tsx`): extracted `NEUTRAL_KIND_CLASS` constant to eliminate eight identical class string repetitions
+- `CHANGELOG.md`: removed blank-line artifacts within `### Added` and `### Changed` sections left by the duplicate-section merge in #28
+
 ### Changed
 
 - sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors
-
 - narrowed the Tailwind Plus REUSE attribution so only genuinely Commit-template-derived changelog source files carry `LicenseRef-TailwindPlus`, while original SecPal source files now declare plain AGPL directly in their own SPDX headers
 - replaced the generic changelog brand glyphs with the canonical SecPal logo in the header, reused the canonical `SecPal – A guard's best friend` tagline in the footer, kept the dark brand asset for the always-dark intro sidebar in light mode, switched the `secpal.app` link treatment to the canonical monochrome SecPal logo derived from the frontend brand assets, and added light/dark theme-aware browser icons
 - refreshed `package-lock.json` with `npm audit fix --package-lock-only`, clearing the remaining transitive `npm audit` findings and aligning the lockfile package name with `secpal-changelog`

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -20,24 +20,22 @@ interface LabelProps {
   children: React.ReactNode
 }
 
+const NEUTRAL_KIND_CLASS =
+  'text-gray-500 border-gray-300 dark:text-gray-400 dark:border-gray-600'
+
 const KIND_CLASSES: Record<LabelKind, string> = {
-  added:
-    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  improved:
-    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  fixed:
-    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  changed:
-    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  android:
-    'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  api: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  web: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
-  auth: 'text-gray-500 border-gray-300   dark:text-gray-400 dark:border-gray-600',
+  added: NEUTRAL_KIND_CLASS,
+  improved: NEUTRAL_KIND_CLASS,
+  fixed: NEUTRAL_KIND_CLASS,
+  changed: NEUTRAL_KIND_CLASS,
+  android: NEUTRAL_KIND_CLASS,
+  api: NEUTRAL_KIND_CLASS,
+  web: NEUTRAL_KIND_CLASS,
+  auth: NEUTRAL_KIND_CLASS,
   security:
     'text-amber-700/80 border-amber-400/40 dark:text-amber-400/70 dark:border-amber-600/40',
   breaking:
-    'text-red-700/80   border-red-300/40   dark:text-red-400/70   dark:border-red-700/40',
+    'text-red-700/80 border-red-300/40 dark:text-red-400/70 dark:border-red-700/40',
 }
 
 /**

--- a/src/components/WhyItMatters.tsx
+++ b/src/components/WhyItMatters.tsx
@@ -12,11 +12,11 @@
  */
 export function WhyItMatters({ children }: { children: React.ReactNode }) {
   return (
-    <p className="border-l-2 border-sky-600/30 pl-4 text-sm/6 text-gray-500 italic dark:border-sky-500/25 dark:text-gray-400">
+    <div className="border-l-2 border-sky-600/30 pl-4 text-sm/6 text-gray-500 italic dark:border-sky-500/25 dark:text-gray-400">
       <span className="font-semibold text-gray-400 not-italic dark:text-gray-500">
         Why it matters:{' '}
       </span>
       {children}
-    </p>
+    </div>
   )
 }


### PR DESCRIPTION
Address Copilot review findings from PRs #28 and #29 that were merged before review was complete.

## Changes

- **`src/components/WhyItMatters.tsx`**: Replace `<p>` wrapper with `<div>` to avoid producing invalid HTML when MDX passes block-level children (e.g. lists or multiple paragraphs). Closes the review finding from #29.
- **`src/components/Label.tsx`**: Extract a `NEUTRAL_KIND_CLASS` constant shared by all eight neutral kinds — eliminates repeated literal strings and makes future style changes a single-line edit. Closes the review finding from #29.
- **`CHANGELOG.md`**: Remove blank-line artifacts within the `### Added` and `### Changed` sections that were left behind by the duplicate `### Changed` section merge in #28. Closes the review finding from #28.

## Checklist

- [x] One topic per PR
- [x] `npm run lint` passes
- [x] `npm run check` (tsc --noEmit) passes
- [x] CHANGELOG.md updated
- [x] Commit is GPG-signed
- [x] No bypasses used
