### PR TITLE
chore: point changelog intro link to roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- intro quick link in `src/components/Intro.tsx` now keeps the SecPal logo mark but points to `https://secpal.app/roadmap` with the label `Roadmap` instead of `secpal.app`
 - sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors
 - narrowed the Tailwind Plus REUSE attribution so only genuinely Commit-template-derived changelog source files carry `LicenseRef-TailwindPlus`, while original SecPal source files now declare plain AGPL directly in their own SPDX headers
 - replaced the generic changelog brand glyphs with the canonical SecPal logo in the header, reused the canonical `SecPal – A guard's best friend` tagline in the footer, kept the dark brand asset for the always-dark intro sidebar in light mode, switched the `secpal.app` link treatment to the canonical monochrome SecPal logo derived from the frontend brand assets, and added light/dark theme-aware browser icons

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -44,11 +44,11 @@ export function Intro() {
       </p>
       <div className="mt-8 flex flex-wrap justify-center gap-x-1 gap-y-3 sm:gap-x-2 lg:justify-start">
         <IconLink
-          href="https://secpal.app"
+          href="https://secpal.app/roadmap"
           icon={LogoMarkMonochromeIcon}
           className="flex-none"
         >
-          secpal.app
+          Roadmap
         </IconLink>
         <IconLink
           href="https://github.com/SecPal"


### PR DESCRIPTION
## Summary
- replace the intro quick link label on changelog.secpal.app from secpal.app to Roadmap
- keep the SecPal logo mark and point the link at https://secpal.app/roadmap
- document the change in CHANGELOG.md

## Validation
- npm run check
- npm run lint
- npm run build
