### PR TITLE
chore: harden AI findings triage guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,13 @@ At minimum verify:
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID, quality-first, and issue-management checks
 - no bypass was used
 
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
+- Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, static export guarantees, or build-proofed behavior.
+
 ## Repository Conventions
 
 - Stack: Node 22, Next.js 16, Tailwind CSS v4, React 19, MDX, TypeScript strict mode.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,8 +67,8 @@ At minimum verify:
 ## AI Findings Triage
 
 - Treat AI findings and AI-generated fix PRs as hints, not proof.
-- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
-- Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant together with an explanation of how the current code violates it.
+- Green CI alone is not enough for AI-generated changes, especially for test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, static export guarantees, or build-proofed behavior.
 
 ## Repository Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dependabot npm updates now ignore unsupported major `eslint` bumps until the Next.js lint stack supports ESLint 10+
-- strengthened repo-local Copilot governance for AI findings: changelog-site work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, markup, or static-export refactors
+- Strengthened repo-local Copilot governance for AI findings: changelog-site work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, markup, or static export refactors
 
 - intro quick link in `src/components/Intro.tsx` now keeps the SecPal logo mark but points to `https://secpal.app/roadmap` with the label `Roadmap` instead of `secpal.app`
 - sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dependabot npm updates now ignore unsupported major `eslint` bumps until the Next.js lint stack supports ESLint 10+
+- strengthened repo-local Copilot governance for AI findings: changelog-site work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, markup, or static-export refactors
 
 - intro quick link in `src/components/Intro.tsx` now keeps the SecPal logo mark but points to `https://secpal.app/roadmap` with the label `Roadmap` instead of `secpal.app`
 - sharpened hero entry copy in `src/app/page.mdx`: headline → "Building SecPal in public", intro split into two shorter paragraphs with "We build in the open.", list simplified to bare app identifiers, section title → "What's in progress", list items trimmed of trailing descriptors


### PR DESCRIPTION
Closes #46
Refs SecPal/.github#367

## Summary

- add AI findings triage guidance to the changelog-site repository baseline
- require proof of defect before merging AI-generated content or markup refactors

## Validation

- `/home/secpal/code/SecPal/.github/scripts/validate-copilot-instructions.sh`
- targeted markdown lint from `/home/secpal/code/SecPal/.github`
