### PR TITLE
chore: track changelog preflight exclusions

### DIFF
--- a/.preflight-exclude
+++ b/.preflight-exclude
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-License-Identifier: CC0-1.0
+
+# Preflight PR Size Check - Excluded Files
+# ==========================================
+# Files matching these patterns are excluded from the 600-line PR size check.
+# Each line is a grep-compatible regex pattern.
+
+# This file should match the exclusions consumed by the shared PR size workflow.
+
+# Dependency lock files (auto-generated)
+package-lock.json
+
+# License files (boilerplate)
+^LICENSES/.*\.txt$

--- a/.preflight-exclude
+++ b/.preflight-exclude
@@ -3,13 +3,13 @@
 
 # Preflight PR Size Check - Excluded Files
 # ==========================================
-# Files matching these patterns are excluded from the 600-line PR size check.
+# Files matching these patterns are excluded from the PR size check.
 # Each line is a grep-compatible regex pattern.
 
 # This file should match the exclusions consumed by the shared PR size workflow.
 
 # Dependency lock files (auto-generated)
-package-lock.json
+^package-lock\.json$
 
 # License files (boilerplate)
 ^LICENSES/.*\.txt$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- tracked `.preflight-exclude` so shared PR-size checks ignore changelog-specific generated churn in `package-lock.json` and `LICENSES/*.txt`
+
 ### Improved
 
 - dependency-upgrade resilience: `StarField` no longer depends on `motion` timeline APIs removed by newer majors, and MDX syntax highlighting now supports both legacy and modern `shiki` export shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - tracked `.preflight-exclude` so shared PR-size checks ignore changelog-specific generated churn in `package-lock.json` and `LICENSES/*.txt`
-
-### Improved
-
-- dependency-upgrade resilience: `StarField` no longer depends on `motion` timeline APIs removed by newer majors, and MDX syntax highlighting now supports both legacy and modern `shiki` export shapes
-
-- visual polish pass: h2 release titles enlarged to `text-2xl` with tight letter-spacing for clearer hierarchy; h2 top spacing increased to `margin.10`; list item gap tightened to `margin.3`; inter-article spacing reduced from `space-y-32` to `space-y-28` on desktop; article header bottom margin narrowed from `mb-10` to `mb-8`; `WhyItMatters` callout border opacity and left padding slightly increased for better presence
-
-### Added
-
 - `Label` and `Labels` components (`src/components/Label.tsx`): lightweight per-entry taxonomy badges with kinds `added | improved | fixed | changed | android | api | web | auth | security | breaking`; neutrals share one style, `security` gets an amber tint, `breaking` a red tint — registered globally in `mdx.tsx` so MDX files need no explicit import
 - `WhyItMatters` component (`src/components/WhyItMatters.tsx`): optional callout line for significant entries; renders as a subtle left-border callout block with "Why it matters:" prefix — registered globally in `mdx.tsx`
 - demonstrative usage of both components in `src/app/page.mdx`: scope labels on the hero entry, `WhyItMatters` closing the in-progress section
@@ -34,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/generate-feed.mjs`: post-build script that reads `out/index.html` and generates `out/feed.xml`
 - local repository guardrails: `scripts/check-conflict-markers.sh`, `scripts/check-domains.sh`, and `scripts/preflight.sh`
 - `scripts/generate-csp.mjs`: build-time CSP generator that derives the required `script-src` hashes from exported HTML and produces a deployable nginx snippet
+
+### Improved
+
+- dependency-upgrade resilience: `StarField` no longer depends on `motion` timeline APIs removed by newer majors, and MDX syntax highlighting now supports both legacy and modern `shiki` export shapes
+
+- visual polish pass: h2 release titles enlarged to `text-2xl` with tight letter-spacing for clearer hierarchy; h2 top spacing increased to `margin.10`; list item gap tightened to `margin.3`; inter-article spacing reduced from `space-y-32` to `space-y-28` on desktop; article header bottom margin narrowed from `mb-10` to `mb-8`; `WhyItMatters` callout border opacity and left padding slightly increased for better presence
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- add a tracked `.preflight-exclude` so the shared PR-size check ignores changelog-specific generated churn
- keep the exclusions repo-appropriate by limiting them to `package-lock.json` and `LICENSES/*.txt`
- document the configuration change in `CHANGELOG.md`

## Validation

- verify `.preflight-exclude` becomes tracked via `git ls-files --error-unmatch .preflight-exclude`
- validate exclusion matching for `package-lock.json`, `LICENSES/AGPL-3.0-or-later.txt`, and non-matching `package.json`
- reuse lint

## Related

- Closes #40

## Checklist

- [x] Single topic
- [x] Repo-visible configuration change documented in `CHANGELOG.md`
- [x] Lightweight validation completed
