### PR TITLE
chore: automate Copilot AI validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,7 @@ At minimum verify:
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant together with an explanation of how the current code violates it.
 - Green CI alone is not enough for AI-generated changes, especially for test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, static export guarantees, or build-proofed behavior.
+- Reject AI-generated MDX, markup, label, or feed refactors that do not prove the exported page, metadata, static build output, and feed behavior remain equivalent after the change.
 
 ## Repository Conventions
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,6 +30,10 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
+  copilot-instructions:
+    name: Copilot Instructions
+    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+
   eslint:
     name: ESLint
     uses: SecPal/.github/.github/workflows/reusable-node-lint.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - local repository guardrails: `scripts/check-conflict-markers.sh`, `scripts/check-domains.sh`, and `scripts/preflight.sh`
 - `scripts/generate-csp.mjs`: build-time CSP generator that derives the required `script-src` hashes from exported HTML and produces a deployable nginx snippet
 
+### Changed
+
+- wired the central Copilot-instructions validator into `quality.yml` so changelog pull requests now fail automatically when known MDX, markup, or static-export AI-risk guardrails are missing from the runtime baseline
+
 ### Improved
 
 - dependency-upgrade resilience: `StarField` no longer depends on `motion` timeline APIs removed by newer majors, and MDX syntax highlighting now supports both legacy and modern `shiki` export shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - local repository guardrails: `scripts/check-conflict-markers.sh`, `scripts/check-domains.sh`, and `scripts/preflight.sh`
 - `scripts/generate-csp.mjs`: build-time CSP generator that derives the required `script-src` hashes from exported HTML and produces a deployable nginx snippet
 
-### Changed
-
-- wired the central Copilot-instructions validator into `quality.yml` so changelog pull requests now fail automatically when known MDX, markup, or static-export AI-risk guardrails are missing from the runtime baseline
-
 ### Improved
 
 - dependency-upgrade resilience: `StarField` no longer depends on `motion` timeline APIs removed by newer majors, and MDX syntax highlighting now supports both legacy and modern `shiki` export shapes
@@ -38,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- wired the central Copilot-instructions validator into `quality.yml` so changelog pull requests now fail automatically when known MDX, markup, or static-export AI-risk guardrails are missing from the runtime baseline
 - Dependabot npm updates now ignore unsupported major `eslint` bumps until the Next.js lint stack supports ESLint 10+
 - Strengthened repo-local Copilot governance for AI findings: changelog-site work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, markup, or static export refactors
 


### PR DESCRIPTION
## Summary

- wire the shared Copilot-instructions validator into the changelog quality workflow
- extend changelog runtime guardrails for MDX, markup, label, and static-export regressions

## Testing

- bash /home/holger/code/SecPal/.github/scripts/validate-copilot-instructions.sh

## Issues

- Closes #54
- Part of SecPal/.github#373
