### PR TITLE
Clarify under-1.x compatibility removal guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ At minimum verify:
 - Green CI alone is not enough for AI-generated changes, especially for test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, static export guarantees, or build-proofed behavior.
 - Reject AI-generated MDX, markup, label, or feed refactors that do not prove the exported page, metadata, static build output, and feed behavior remain equivalent after the change.
-- Reject AI-generated compatibility keep-alives that preserve obsolete content contracts, metadata aliases, or storage/input shims without a proven live caller. Because the SecPal project is still under `1.x`, prefer removing unnecessary compatibility paths over carrying them forward when they add noise, ambiguity, or maintenance cost.
+- Reject AI-generated compatibility keep-alives that preserve obsolete content contracts, metadata aliases, or storage/input shims without a proven live caller. Because the SecPal project is still pre-`1.0.0`, prefer removing unnecessary compatibility paths over carrying them forward when they add noise, ambiguity, or maintenance cost.
 
 ## Repository Conventions
 
@@ -86,4 +86,4 @@ At minimum verify:
 
 - Do not add dependencies or create documentation files unless the task requires them.
 - The MVP has no search, no pagination, and no per-entry permalink pages — all content is a single page. Keep it that way unless a specific issue requires otherwise.
-- Because the SecPal project is still under `1.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update validation and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.
+- Because the SecPal project is still pre-`1.0.0`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update the relevant formatting, lint, and build validation and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,7 @@ At minimum verify:
 - Green CI alone is not enough for AI-generated changes, especially for test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated content or styling cleanups that only look simpler in the diff but weaken HTML validity, static export guarantees, or build-proofed behavior.
 - Reject AI-generated MDX, markup, label, or feed refactors that do not prove the exported page, metadata, static build output, and feed behavior remain equivalent after the change.
+- Reject AI-generated compatibility keep-alives that preserve obsolete content contracts, metadata aliases, or storage/input shims without a proven live caller. Because the SecPal project is still under `1.x`, prefer removing unnecessary compatibility paths over carrying them forward when they add noise, ambiguity, or maintenance cost.
 
 ## Repository Conventions
 
@@ -85,3 +86,4 @@ At minimum verify:
 
 - Do not add dependencies or create documentation files unless the task requires them.
 - The MVP has no search, no pagination, and no per-entry permalink pages — all content is a single page. Keep it that way unless a specific issue requires otherwise.
+- Because the SecPal project is still under `1.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update validation and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- clarified the repo-local under-`1.x` policy in Copilot governance so changelog work explicitly prefers removing obsolete compatibility shims over carrying them forward without a proven live caller
 - wired the central Copilot-instructions validator into `quality.yml` so changelog pull requests now fail automatically when known MDX, markup, or static-export AI-risk guardrails are missing from the runtime baseline
 - Dependabot npm updates now ignore unsupported major `eslint` bumps until the Next.js lint stack supports ESLint 10+
 - Strengthened repo-local Copilot governance for AI findings: changelog-site work now requires proof of defect before merging AI-generated fix PRs and treats green CI alone as insufficient evidence for content, markup, or static export refactors


### PR DESCRIPTION
## Summary
- clarify the repo-local Copilot guidance for the project-wide under-1.x compatibility-removal policy
- document the governance change in the changelog repository changelog

## Validation
- git diff --check

Closes #58
